### PR TITLE
feat: add routing and diagram tool navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,15 @@
-// import ReportDesigner, {
-//   RequestOptions,
-//   DesignerModelSettings,
-//   PreviewSettings,
-//   DataSourceSettings,
-//   WizardSettings,
-//   Callbacks
-// } from 'devexpress-reporting-react/dx-report-designer';
-// import { ActionId } from 'devexpress-reporting/dx-reportdesigner';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import ReportsPage from './pages/ReportsPage';
+import DiagramTool from './components/DiagramTool';
 
-// export default function App() {
-//   // Example: tweak menu actions
-//   const onCustomizeMenuActions = ({ args }: { args: any }) => {
-//     const newReport = args.GetById(ActionId.NewReport);
-//     if (newReport) newReport.visible = false; // demo: hide "New Report"
-//   };
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<ReportsPage />} />
+        <Route path="/diagram" element={<DiagramTool />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
 
-//   return (
-//     <div style={{ height: '100dvh', width: '100%' }}>
-//       <ReportDesigner reportUrl="TestReport">
-//         <RequestOptions
-//           host={import.meta.env.VITE_DX_HOST}
-//           getDesignerModelAction="DXXRD/GetDesignerModel"
-//         />
-//         <Callbacks CustomizeMenuActions={onCustomizeMenuActions} />
-//         <DesignerModelSettings allowMDI>
-//           <DataSourceSettings allowAddDataSource={false} allowRemoveDataSource={false} />
-//           <PreviewSettings>
-//             <WizardSettings useFullscreenWizard={false} />
-//           </PreviewSettings>
-//         </DesignerModelSettings>
-//       </ReportDesigner>
-//     </div>
-//   );
-// }

--- a/src/components/DiagramTool.tsx
+++ b/src/components/DiagramTool.tsx
@@ -8,7 +8,7 @@ import ReportDesigner, {
 } from 'devexpress-reporting-react/dx-report-designer';
 import { ActionId } from 'devexpress-reporting/dx-reportdesigner';
 
-export default function App() {
+export default function DiagramTool() {
   // Example: tweak menu actions
   const onCustomizeMenuActions = ({
     args

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,5 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-//import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import 'devextreme/dist/css/dx.light.css';
 import '@devexpress/analytics-core/dist/css/dx-analytics.common.css';
 import '@devexpress/analytics-core/dist/css/dx-analytics.light.css';
@@ -10,11 +9,11 @@ import 'ace-builds/css/theme/dreamweaver.css';
 import '@progress/kendo-theme-default/dist/all.css';
 import './styles/index.css';
 import './styles/kendo-overrides.css';
-import ReportsPage from './pages/ReportsPage';
-
+import App from './App';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ReportsPage />
+    <App />
   </StrictMode>,
-)
+);
+

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -12,6 +12,7 @@ import {
   DropDownList,
   type DropDownListChangeEvent
 } from '@progress/kendo-react-dropdowns';
+import { useNavigate } from 'react-router-dom';
 
 type ReportRow = {
   id: number;
@@ -47,6 +48,7 @@ export default function ReportsPage() {
   const [company, setCompany] = React.useState<number | null>(null);
   const [query, setQuery] = React.useState<string>('');
   const [selectedReportId, setSelectedReportId] = React.useState<number | null>(null);
+  const navigate = useNavigate();
 
   const companies: Company[] = React.useMemo(
     () => [
@@ -111,6 +113,10 @@ export default function ReportsPage() {
   const onRowClick = (e: GridRowClickEvent) => {
     const row = e.dataItem as ReportRow;
     setSelectedReportId(row.id);
+  };
+
+  const onHistoryRowClick = () => {
+    navigate('/diagram');
   };
 
   const selectedCompanyObj = companies.find(c => c.id === company) ?? null;
@@ -179,7 +185,7 @@ export default function ReportsPage() {
           {selectedReportId != null && (
             <div>
               <h3 style={{ marginBottom: 8 }}>Version History</h3>
-              <Grid data={visibleVersions}>
+              <Grid data={visibleVersions} onRowClick={onHistoryRowClick}>
                 <GridToolbar>
                   <Button themeColor="error" icon="trash">Delete</Button>
                 </GridToolbar>


### PR DESCRIPTION
## Summary
- configure BrowserRouter routes for reports and diagram pages
- use navigate to open diagram tool when selecting a version
- expose diagram designer as a route component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b93d804510832daf4bb277dcf402d1